### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/legnoh/withings-exporter/security/code-scanning/14](https://github.com/legnoh/withings-exporter/security/code-scanning/14)

To resolve this issue, you should set the `permissions:` key in your workflow YAML. The best way is to limit the GITHUB_TOKEN used by the workflow to the minimal permissions required for the job. For most CI workflows that build and push Docker images and update descriptions, they don't need write access to repository contents unless explicitly interacting with git, pull requests, or repo content. The recommended fix is to add:
```yaml
permissions:
  contents: read
```
at the top level of the workflow file (before `jobs:`), which will apply to all jobs (unless they declare their own permissions block). Examine the workflow for potential needs of other scopes (such as `pull-requests: write`), but in this snippet, `contents: read` suffices as the starting minimal set.

**What to change:**  
Edit the file `.github/workflows/ci.yml` and add the following block after the workflow name and before `on:` (e.g., after line 1):

```yaml
permissions:
  contents: read
```

No new imports or code definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
